### PR TITLE
Updated request-source syntax highlight

### DIFF
--- a/syntax/requester-source-identifiers.tmPreferences
+++ b/syntax/requester-source-identifiers.tmPreferences
@@ -12,8 +12,7 @@
       <integer>1</integer>
       <key>symbolTransformation</key>
       <string>
-         s/(requests\.)?(get|options|head|post|put|patch|delete)(.*)/\U\2\E:\3/g;
-         s/\(/ /g;
+         s/.*?(get|options|head|post|put|patch|delete)\s*\(\s*(.*)/\U\1\E: \2/g;
       </string>
    </dict>
 </dict>

--- a/syntax/requester-source.sublime-syntax
+++ b/syntax/requester-source.sublime-syntax
@@ -13,8 +13,11 @@ contexts:
           push: env
         - match: "^(?=##)"
           push: header
-        - match: ^(?=([\w_][\w\d_]*\.)?(get|options|head|post|put|patch|delete))
-          push: identifier
+        - match: ^([\w_][\w\d_]*\.)?(get|options|head|post|put|patch|delete)\s*(\()
+          captures:
+            2: variable.function.python
+            3: punctuation.section.arguments.begin.python
+          push: [function-call, identifier]
 
   env:
     - match: "\n"
@@ -28,13 +31,16 @@ contexts:
     - match: .*
       scope: storage.header.requester
 
-  identifier:
-    - meta_content_scope: meta.identifier.requester
-    - match: "[,)]"
+  function-call:
+    - meta_scope: meta.function-call.python
+    - match: \)
+      scope: punctuation.section.arguments.end.python
       pop: true
-    - match: "'.*?'"
-      scope: string.quoted.single.python
-    - match: '".*?"'
-      scope: string.quoted.double.python
-    - match: '\+'
-      scope: keyword.operator.arithmetic.python
+    - include: "Packages/Python/Python.sublime-syntax#arguments"
+
+  identifier:
+    - meta_scope: meta.identifier.requester
+    - match: (?=[,)])
+      pop: true
+    - include: "Packages/Python/Python.sublime-syntax#arguments"
+


### PR DESCRIPTION
As it stands now, the `with_prototype` override `requester-source.sublime-syntax` uses to add the `meta.identifier.requester` scope results in the closing `)` of a "request" function call getting the `invalid` scope (and the corresponding red background for color schemes that highlight it), and it also prevents the function arguments from being highlighted correctly by the Python syntax highlighter.

This pull request is a proposal for changing this. I am of course not aware of all of your design decisions so feel free to disregard my suggestion - I would like to see the removal of the `invalid` scope in any case. 

I also tweaked the symbol transformation to match whitespace outside of the capture groups; this keeps the spacing in the symbol list consistent no matter how the function is laid out. Again, there may be reasons you didn't do this, so I don't mind it at all if you disregard this.

I have just started playing with your package and it is awesome 👍  - thank you!