### PR TITLE
Support any cursor position on multiline requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ get(
 Body, Query Params, and Headers are passed to __requests__ as dictionaries. And for executing requests defined over multiple lines, you have two options:
 
 - fully highlight one or more requests and execute them
-- place your cursor on the __first line__ of a request and execute it
+- place your cursor inside of a request and execute it
 
 Try it out.
 

--- a/commands/request.py
+++ b/commands/request.py
@@ -141,6 +141,7 @@ def set_response_view_name(view, res=None):
 class RequestsMixin:
     def get_requests(self):
         """Parses requests from multiple selections. If nothing is highlighted,
+        checks for request containing cursor's current position, otherwise
         cursor's current line is taken as selection.
         """
         view = self.view
@@ -148,6 +149,17 @@ class RequestsMixin:
         for region in view.sel():
             if not region.empty():
                 selection = view.substr(region)
+                try:
+                    requests_ = parse_requests(selection)
+                except Exception as e:
+                    sublime.error_message('Parse Error: there may be unbalanced parentheses in calls to requests')
+                    print(e)
+                    continue
+            elif view.match_selector(region.begin(), 'source.requester meta.function-call.python'):
+                for func_region in view.find_by_selector('source.requester meta.function-call.python'):
+                    if func_region.contains(region):
+                        selection = view.substr(func_region)
+                        break
                 try:
                     requests_ = parse_requests(selection)
                 except Exception as e:

--- a/docs/_content/body.md
+++ b/docs/_content/body.md
@@ -36,7 +36,7 @@ Go back to your requester file and save it as `<anything>.pyr`. The extension is
 For executing requests defined over multiple lines, you have two options:
 
 - fully highlight one or more requests and execute them
-- place your cursor on the __first line__ of a request and execute it
+- place your cursor inside of a request and execute it
 
 ~~~py
 get(

--- a/docs/_content/intro.md
+++ b/docs/_content/intro.md
@@ -42,7 +42,7 @@ get(
 Body, Query Params, and Headers are passed to __requests__ as dictionaries. And for executing requests defined over multiple lines, you have two options:
 
 - fully highlight one or more requests and execute them
-- place your cursor on the __first line__ of a request and execute it
+- place your cursor inside of a request and execute it
 
 Try it out.
 

--- a/tests/requester.py
+++ b/tests/requester.py
@@ -8,3 +8,7 @@ get('127.0.0.1:8000/get')
 
 requests.get(base_url, params={'key1': 'value1'})
 requests.post('http://127.0.0.1:8000/anything')
+
+requests.get(
+    '127.0.0.1:8000/get'
+)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -122,6 +122,15 @@ class TestRequester(TestRequesterMixin, DeferrableTestCase):
         self._test_url_in_view(self.window.active_view(), 'http://127.0.0.1:8000/get')
         self._test_name_in_view(self.window.active_view(), 'GET: /get')
 
+    def test_single_request_on_multiple_lines(self):
+        """Request on multiple lines.
+        """
+        select_line_beginnings(self.view, 13)
+        self.view.run_command('requester')
+        yield self.WAIT_MS
+        self._test_url_in_view(self.window.active_view(), 'http://127.0.0.1:8000/get')
+        self._test_name_in_view(self.window.active_view(), 'GET: /get')
+
     def test_single_request_with_env_block(self):
         """From env block.
         """


### PR DESCRIPTION
This change allows you to execute requests when the cursor is at any point inside of a multiline request. It does this by using Sublime Text's `view.find_by_selector()` API method to locate the full extent of the request even when it is spread over multiple lines. I tried to keep the changes to `commands/request.py` to a minimum, however what I added could possibly be optimized. For instance `find_by_selector` really only needs to be called once, and not for every region in `view.sel()`. In practice though this probably doesn't matter speed wise.

Note: I ended up committing without passing flake8 since it complains about a number of `bare excepts` throughout the repo, and I didn't want to be editing code that wasn't my own. Those were the only failures, though.